### PR TITLE
add agenda sync api

### DIFF
--- a/src/app/api/agenda/sync/route.ts
+++ b/src/app/api/agenda/sync/route.ts
@@ -1,0 +1,244 @@
+import { NextResponse } from "next/server";
+import {
+    computeAppointmentId,
+    getAgendaDb,
+    newId,
+    normalizeOneLine,
+    nowMs,
+    parseDateKey,
+    parseTimeKey,
+    toUnitSlug,
+} from "@/lib/agendaDb";
+
+export const dynamic = "force-dynamic";
+
+type AppointmentPayload = {
+    data?: string;
+    horario?: string;
+    cliente?: string;
+    tipo?: string;
+    profissional?: string;
+    telefone?: string;
+    cpf?: string;
+    source?: string;
+    servico?: string;
+    observacoes?: string;
+    status?: string;
+};
+
+type RemovalPayload = {
+    data?: string;
+    horario?: string;
+    cliente?: string;
+    tipo?: string;
+    profissional?: string;
+};
+
+type Payload = {
+    unit?: string;
+    added?: AppointmentPayload[];
+    removed?: RemovalPayload[];
+    runId?: string;
+};
+
+function json(data: unknown, init?: ResponseInit) {
+    return NextResponse.json(data, init);
+}
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) {
+        return auth.slice(7).trim();
+    }
+    return (request.headers.get("x-agenda-sync-token") ?? "").trim();
+}
+
+function assertToken(request: Request): boolean {
+    const secret = (process.env.AGENDA_SYNC_TOKEN ?? "").trim();
+    if (!secret) return true;
+    return readToken(request) === secret;
+}
+
+export async function POST(request: Request) {
+    if (!assertToken(request)) {
+        return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+
+    let body: Payload;
+    try {
+        body = (await request.json()) as Payload;
+    } catch {
+        return json({ ok: false, error: "invalid_json" }, { status: 400 });
+    }
+
+    const unitSlug = toUnitSlug(body.unit ?? "");
+    if (!unitSlug) {
+        return json({ ok: false, error: "missing_unit" }, { status: 400 });
+    }
+    if (unitSlug !== "barrashoppingsul" && unitSlug !== "novo-hamburgo") {
+        return json({ ok: false, error: "invalid_unit" }, { status: 400 });
+    }
+
+    const added = Array.isArray(body.added) ? body.added : [];
+    const removed = Array.isArray(body.removed) ? body.removed : [];
+
+    const db = await getAgendaDb();
+    const now = nowMs();
+
+    let addedOk = 0;
+    let addedSkipped = 0;
+    let removedOk = 0;
+    let removedSkipped = 0;
+
+    for (const item of added) {
+        const dateKey = parseDateKey(item.data ?? "");
+        const timeKey = parseTimeKey(item.horario ?? "");
+        const client = normalizeOneLine(item.cliente ?? "");
+        const tipo = normalizeOneLine(item.tipo ?? "");
+        const profissional = normalizeOneLine(item.profissional ?? "");
+        if (!dateKey || !timeKey || !client || !tipo || !profissional) {
+            addedSkipped += 1;
+            continue;
+        }
+
+        const appointmentId = computeAppointmentId({
+            unitSlug,
+            dateKey,
+            timeKey,
+            client,
+            tipo,
+            profissional,
+        });
+
+        await db
+            .prepare(
+                `INSERT INTO agenda_appointments (
+                    appointment_id,
+                    unit_slug,
+                    date_key,
+                    time_key,
+                    client,
+                    tipo,
+                    profissional,
+                    telefone,
+                    cpf,
+                    source,
+                    service,
+                    notes,
+                    status,
+                    created_at_ms,
+                    updated_at_ms,
+                    last_seen_at_ms,
+                    removed_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(appointment_id) DO UPDATE SET
+                    unit_slug = excluded.unit_slug,
+                    date_key = excluded.date_key,
+                    time_key = excluded.time_key,
+                    client = excluded.client,
+                    tipo = excluded.tipo,
+                    profissional = excluded.profissional,
+                    telefone = excluded.telefone,
+                    cpf = excluded.cpf,
+                    source = excluded.source,
+                    service = excluded.service,
+                    notes = excluded.notes,
+                    status = excluded.status,
+                    updated_at_ms = excluded.updated_at_ms,
+                    last_seen_at_ms = excluded.last_seen_at_ms,
+                    removed_at_ms = NULL;`,
+            )
+            .bind(
+                appointmentId,
+                unitSlug,
+                dateKey,
+                timeKey,
+                client,
+                tipo,
+                profissional,
+                normalizeOneLine(item.telefone ?? ""),
+                normalizeOneLine(item.cpf ?? ""),
+                normalizeOneLine(item.source ?? ""),
+                normalizeOneLine(item.servico ?? ""),
+                normalizeOneLine(item.observacoes ?? ""),
+                normalizeOneLine(item.status ?? ""),
+                now,
+                now,
+                now,
+            )
+            .run();
+
+        await db
+            .prepare(
+                `INSERT INTO agenda_changes (
+                    id, unit_slug, change_type, appointment_id, date_key, time_key, client, tipo, profissional, created_at_ms
+                ) VALUES (?, ?, 'added', ?, ?, ?, ?, ?, ?, ?);`,
+            )
+            .bind(newId(), unitSlug, appointmentId, dateKey, timeKey, client, tipo, profissional, now)
+            .run();
+
+        addedOk += 1;
+    }
+
+    for (const item of removed) {
+        const dateKey = parseDateKey(item.data ?? "");
+        const timeKey = parseTimeKey(item.horario ?? "");
+        const client = normalizeOneLine(item.cliente ?? "");
+        const tipo = normalizeOneLine(item.tipo ?? "");
+        const profissional = normalizeOneLine(item.profissional ?? "");
+        if (!dateKey || !timeKey) {
+            removedSkipped += 1;
+            continue;
+        }
+
+        let appointmentId: string | null = null;
+        if (client && tipo && profissional) {
+            appointmentId = computeAppointmentId({
+                unitSlug,
+                dateKey,
+                timeKey,
+                client,
+                tipo,
+                profissional,
+            });
+            await db
+                .prepare(
+                    `UPDATE agenda_appointments
+                     SET removed_at_ms = ?
+                     WHERE appointment_id = ? AND removed_at_ms IS NULL;`,
+                )
+                .bind(now, appointmentId)
+                .run();
+        } else {
+            await db
+                .prepare(
+                    `UPDATE agenda_appointments
+                     SET removed_at_ms = ?
+                     WHERE unit_slug = ? AND date_key = ? AND time_key = ? AND removed_at_ms IS NULL;`,
+                )
+                .bind(now, unitSlug, dateKey, timeKey)
+                .run();
+        }
+
+        await db
+            .prepare(
+                `INSERT INTO agenda_changes (
+                    id, unit_slug, change_type, appointment_id, date_key, time_key, client, tipo, profissional, created_at_ms
+                ) VALUES (?, ?, 'removed', ?, ?, ?, ?, ?, ?, ?);`,
+            )
+            .bind(newId(), unitSlug, appointmentId, dateKey, timeKey, client, tipo, profissional, now)
+            .run();
+
+        removedOk += 1;
+    }
+
+    return json({
+        ok: true,
+        unit: unitSlug,
+        added: addedOk,
+        removed: removedOk,
+        added_skipped: addedSkipped,
+        removed_skipped: removedSkipped,
+        runId: body.runId ?? null,
+    });
+}

--- a/src/lib/agendaDb.ts
+++ b/src/lib/agendaDb.ts
@@ -1,0 +1,162 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+type D1PreparedStatement = {
+    bind: (...values: unknown[]) => D1PreparedStatement;
+    first: <T = unknown>() => Promise<T | null>;
+    all: <T = unknown>() => Promise<{ results: T[] }>;
+    run: () => Promise<{ success: boolean; error?: string } | unknown>;
+};
+
+type D1DatabaseLike = {
+    prepare: (query: string) => D1PreparedStatement;
+    exec: (query: string) => Promise<unknown>;
+};
+
+type CloudflareEnv = {
+    BOOKING_DB?: D1DatabaseLike;
+};
+
+function getDbOrThrow(): D1DatabaseLike {
+    const { env } = getCloudflareContext();
+    const typedEnv = env as unknown as CloudflareEnv;
+    const db = typedEnv.BOOKING_DB;
+    if (!db) {
+        throw new Error("BOOKING_DB_not_configured");
+    }
+    return db;
+}
+
+let ensured = false;
+
+export async function getAgendaDb(): Promise<D1DatabaseLike> {
+    const db = getDbOrThrow();
+    if (!ensured) {
+        await ensureSchema(db);
+        ensured = true;
+    }
+    return db;
+}
+
+async function ensureSchema(db: D1DatabaseLike) {
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS agenda_appointments (
+                appointment_id TEXT PRIMARY KEY,
+                unit_slug TEXT NOT NULL,
+                date_key TEXT NOT NULL,
+                time_key TEXT NOT NULL,
+                client TEXT NOT NULL,
+                tipo TEXT NOT NULL,
+                profissional TEXT NOT NULL,
+                telefone TEXT,
+                cpf TEXT,
+                source TEXT,
+                service TEXT,
+                notes TEXT,
+                status TEXT,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                last_seen_at_ms INTEGER NOT NULL,
+                removed_at_ms INTEGER
+            );`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE INDEX IF NOT EXISTS idx_agenda_unit_date_time
+             ON agenda_appointments(unit_slug, date_key, time_key);`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS agenda_changes (
+                id TEXT PRIMARY KEY,
+                unit_slug TEXT NOT NULL,
+                change_type TEXT NOT NULL,
+                appointment_id TEXT,
+                date_key TEXT,
+                time_key TEXT,
+                client TEXT,
+                tipo TEXT,
+                profissional TEXT,
+                created_at_ms INTEGER NOT NULL
+            );`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE INDEX IF NOT EXISTS idx_agenda_changes_unit_time
+             ON agenda_changes(unit_slug, created_at_ms);`,
+        )
+        .run();
+}
+
+export function nowMs(): number {
+    return Date.now();
+}
+
+export function normalizeOneLine(value: string): string {
+    return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function normalizeKey(value: string): string {
+    const v = normalizeOneLine(value).toLowerCase();
+    if (!v) return "";
+    return v
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80);
+}
+
+export function toUnitSlug(unit: string): string {
+    const raw = normalizeKey(unit);
+    if (!raw) return "";
+    if (raw === "barrashoppingsul" || raw === "barra-shopping-sul") return "barrashoppingsul";
+    if (raw === "novohamburgo" || raw === "novo-hamburgo") return "novo-hamburgo";
+    return raw;
+}
+
+export function parseDateKey(date: string): string {
+    const raw = normalizeOneLine(date);
+    const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(raw);
+    if (!match) return "";
+    const [, dd, mm, yyyy] = match;
+    return `${yyyy}-${mm}-${dd}`;
+}
+
+export function parseTimeKey(time: string): string {
+    const raw = normalizeOneLine(time);
+    const match = /^(\d{2}):(\d{2})/.exec(raw);
+    if (!match) return "";
+    return `${match[1]}:${match[2]}`;
+}
+
+export function computeAppointmentId(params: {
+    unitSlug: string;
+    dateKey: string;
+    timeKey: string;
+    client: string;
+    tipo: string;
+    profissional: string;
+}): string {
+    const parts = [
+        normalizeKey(params.unitSlug),
+        normalizeKey(params.dateKey),
+        normalizeKey(params.timeKey),
+        normalizeKey(params.client),
+        normalizeKey(params.tipo),
+        normalizeKey(params.profissional),
+    ];
+    return parts.join("|");
+}
+
+export function newId(): string {
+    const anyCrypto = globalThis as unknown as { crypto?: { randomUUID?: () => string } };
+    if (anyCrypto.crypto?.randomUUID) return anyCrypto.crypto.randomUUID();
+    return `chg_${Math.random().toString(16).slice(2)}_${Date.now()}`;
+}


### PR DESCRIPTION
## Summary
Adds an authenticated `/api/agenda/sync` endpoint and D1-backed schema to store scraped agenda updates.

## Problem
We need a secure API to upsert appointment changes from the scraper into the Cloudflare D1 database powering espacofacial.com.

## Cause and Effect
Without this endpoint, we only write CSV/Excel outputs locally and cannot keep a near-real-time database for the site.

## Root Cause
There was no server-side API or schema to persist agenda changes in D1.

## Fix
- Added a lightweight agenda D1 schema (`agenda_appointments`, `agenda_changes`) initialized lazily.
- Added `/api/agenda/sync` to accept added/removed appointments and persist them.
- Supports bearer token auth via `AGENDA_SYNC_TOKEN`.

## Tests
Not run (no automated tests in this repo).
