### PR TITLE
[codex] slot tooltip + legenda

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -841,7 +841,19 @@ export default function BookingFlow() {
                     </div>
 
                     <div className={`card bookingFlow__cardFull bookingFlow__cardDateTime ${canPick ? "" : "bookingFlow__card--locked"}`.trim()} style={{ padding: 16 }}>
-                        <div style={{ fontWeight: 900 }}>4) Data e horário</div>
+                        <div className="bookingFlow__cardHeader">
+                            <div style={{ fontWeight: 900 }}>4) Data e horário</div>
+                            <div className="bookingFlow__legend" aria-hidden="true">
+                                <div className="bookingFlow__legendItem">
+                                    <span className="bookingFlow__legendSwatch bookingFlow__legendSwatch--past" />
+                                    Passou
+                                </div>
+                                <div className="bookingFlow__legendItem">
+                                    <span className="bookingFlow__legendSwatch bookingFlow__legendSwatch--occupied" />
+                                    Ocupado
+                                </div>
+                            </div>
+                        </div>
                         <div className="bookingFlow__cardSub">
                             {upcomingDays.length ? `${formatDatePtBr(upcomingDays[0])} – ${formatDatePtBr(upcomingDays[upcomingDays.length - 1] ?? upcomingDays[0])}` : null}
                         </div>
@@ -921,26 +933,34 @@ export default function BookingFlow() {
                                         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(110px, 1fr))", gap: 10 }}>
                                             {slots.slots.map((s) => {
                                                 const active = timeKey === s.time;
-                                                const disabled = !s.available;
-                                        const label =
-                                            s.reason === "booked"
-                                                ? "Indisponível"
-                                                : s.reason === "agenda"
-                                                    ? "Agenda"
-                                                : s.reason === "in_review"
-                                                    ? "Em análise"
-                                                    : s.reason === "past"
-                                                        ? "Passou"
-                                                        : "";
+                                                const isPast = s.reason === "past";
+                                                const isAgenda = s.reason === "agenda";
+                                                const hasTooltip = isPast || isAgenda;
+                                                const tooltip = isPast ? "horário já passou" : isAgenda ? "horário ocupado" : "";
+                                                const ariaDisabled = !s.available;
+                                                const nativeDisabled = !s.available && !hasTooltip;
+                                                const label =
+                                                    isPast || isAgenda
+                                                        ? ""
+                                                        : s.reason === "booked"
+                                                            ? "Indisponível"
+                                                            : s.reason === "in_review"
+                                                                ? "Em análise"
+                                                                : "";
 
                                                 return (
                                                     <button
                                                         key={s.time}
                                                         type="button"
-                                                        disabled={disabled}
+                                                        disabled={nativeDisabled}
+                                                        aria-disabled={ariaDisabled ? "true" : "false"}
+                                                        data-reason={s.reason ?? ""}
+                                                        data-locked={hasTooltip ? "true" : "false"}
+                                                        data-tooltip={hasTooltip ? tooltip : undefined}
                                                         className="bookingFlow__selectItem bookingFlow__timeBtn"
                                                         data-active={active ? "true" : "false"}
                                                         onClick={() => {
+                                                            if (ariaDisabled) return;
                                                             if (active) {
                                                                 setTimeKey(null);
                                                                 setStep("pick");
@@ -955,6 +975,7 @@ export default function BookingFlow() {
                                                             setTurnstileToken(null);
                                                             setTurnstileHadError(false);
                                                         }}
+                                                        tabIndex={ariaDisabled ? -1 : 0}
                                                         style={{
                                                             padding: "12px 12px",
                                                             borderRadius: 12,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -371,6 +371,42 @@ button:focus-visible {
   opacity: 0.8;
 }
 
+.bookingFlow__cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bookingFlow__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.85;
+}
+
+.bookingFlow__legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.bookingFlow__legendSwatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: #f3f4f6;
+}
+
+.bookingFlow__legendSwatch--occupied {
+  background: #e5e7eb;
+  border-color: #d1d5db;
+}
+
 .bookingFlow__selectItem {
   appearance: none;
   background: #fff;
@@ -541,6 +577,86 @@ button:focus-visible {
   color: #777;
   box-shadow: none;
   transform: scale(.98);
+}
+
+.bookingFlow__timeBtn[data-reason="past"] {
+  background: #f3f4f6;
+  color: #9ca3af;
+  border-color: #e5e7eb;
+  box-shadow: none;
+}
+
+.bookingFlow__timeBtn[data-reason="agenda"] {
+  background: #e5e7eb;
+  color: #6b7280;
+  border-color: #d1d5db;
+  box-shadow: none;
+}
+
+.bookingFlow__timeBtn[data-locked="true"] {
+  cursor: default;
+  transform: scale(.98);
+}
+
+.bookingFlow__timeBtn[data-locked="true"]:hover {
+  transform: scale(.98);
+  box-shadow: none;
+}
+
+.bookingFlow__timeBtn[data-locked="true"][data-reason="past"]:hover {
+  background: #f3f4f6;
+  color: #9ca3af;
+  border-color: #e5e7eb;
+}
+
+.bookingFlow__timeBtn[data-locked="true"][data-reason="agenda"]:hover {
+  background: #e5e7eb;
+  color: #6b7280;
+  border-color: #d1d5db;
+}
+
+.bookingFlow__timeBtn[data-tooltip] {
+  position: relative;
+}
+
+.bookingFlow__timeBtn[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%) translateY(4px);
+  padding: 6px 8px;
+  font-size: 11px;
+  line-height: 1.2;
+  color: #fff;
+  background: rgba(17, 17, 17, 0.92);
+  border-radius: 8px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease, transform 140ms ease;
+  z-index: 2;
+}
+
+.bookingFlow__timeBtn[data-tooltip]::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 2px);
+  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  background: rgba(17, 17, 17, 0.92);
+  border-radius: 2px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+  z-index: 1;
+}
+
+.bookingFlow__timeBtn[data-tooltip]:hover::after,
+.bookingFlow__timeBtn[data-tooltip]:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 .bookingFlow__timeBtn:hover:not(:disabled),


### PR DESCRIPTION
## Summary
Update booking slot UI to remove “Passou/Agenda” inline labels, replace them with subtle grey states, add minimal hover tooltips, and show a compact legend beside “4) Data e horário”.

## Problem
- Past and agenda-blocked slots show explicit text (“Passou”, “Agenda”) which adds visual noise.
- No legend explains color meaning; users need to infer.

## Root cause
Slot rendering only supported inline labels and used disabled styles without hover affordances.

## Fix
- Render past/agenda as non-selectable grey states (light/dark) without inline text.
- Add minimal hover popover (“horário já passou” / “horário ocupado”).
- Add a compact legend next to the date/time title.
- Ensure locked items are aria-disabled but still allow hover for tooltip.

## Tests
- `npm run lint`
