### PR TITLE
[codex] past reason priority

### DIFF
--- a/src/app/api/booking/slots/route.ts
+++ b/src/app/api/booking/slots/route.ts
@@ -261,8 +261,8 @@ export async function GET(req: Request) {
             }
         }
 
-        // Prevent booking in the past.
-        if (available && startMs < now) {
+        // Prevent booking in the past (always wins over other reasons).
+        if (startMs < now) {
             available = false;
             reason = "past";
         }


### PR DESCRIPTION
## Summary
Ensure past-time slots always render as "past" even if they were previously occupied, so the UI reflects the most relevant state.

## Problem
When a slot is both occupied and already in the past, the UI may show the occupied state instead of the more relevant "past" state.

## Root cause
The API only set reason="past" when the slot was otherwise available.

## Fix
Always override to reason="past" for slots with start time earlier than now.

## Tests
- Not run (logic-only change)
