### PR TITLE
[codex] fix deploy workflow parse

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
 
     steps:
       - name: Checkout
@@ -41,13 +43,12 @@ jobs:
         run: npm run lint
 
       - name: Sync worker secrets (optional)
-        if: ${{ secrets.TURNSTILE_SECRET_KEY != '' }}
+        if: ${{ env.TURNSTILE_SECRET_KEY != '' }}
         run: |
           printf "%s" "${TURNSTILE_SECRET_KEY}" | npx wrangler secret put TURNSTILE_SECRET_KEY --name espacofacial-site
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
 
       - name: Deploy site (OpenNext -> Workers)
         run: npm run deploy


### PR DESCRIPTION
## Summary
Fix deploy workflow parse error by moving the TURNSTILE secret check to a job env var, so workflow_dispatch and push runs can start.

## Problem
Deploy workflow was failing immediately with “workflow file issue” and could not be dispatched.

## Root cause
The workflow used `secrets` directly in a step `if:` expression, which failed to parse for dispatch.

## Fix
Define `TURNSTILE_SECRET_KEY` at job env and use `if: env.TURNSTILE_SECRET_KEY != ''` for the optional sync step.

## Tests
- Not run (workflow syntax change)
