### PR TITLE
[codex] past overrides occupied

### DIFF
--- a/src/app/api/booking/slots/route.ts
+++ b/src/app/api/booking/slots/route.ts
@@ -226,6 +226,11 @@ export async function GET(req: Request) {
         let available = true;
         let reason: string | null = null;
 
+        // Past times always win over other reasons.
+        if (startMs < now) {
+            return { time, startAtMs: startMs, endAtMs: endMs, available: false, reason: "past" };
+        }
+
         if (agendaRanges.some((r) => r.start < endMs && r.end > startMs)) {
             agendaBlockedCount += 1;
             return { time, available: false, reason: "agenda" };
@@ -259,12 +264,6 @@ export async function GET(req: Request) {
                 available = false;
                 reason = hasPending ? "in_review" : hasConfirmed ? "booked" : "booked";
             }
-        }
-
-        // Prevent booking in the past (always wins over other reasons).
-        if (startMs < now) {
-            available = false;
-            reason = "past";
         }
 
         return {


### PR DESCRIPTION
## Summary
Ensure past-time slots always return reason="past" even if they are also occupied, so UI shows the light-grey passed state for any time before now.

## Problem
Slots that are both occupied and already in the past can still surface as "occupied".

## Root cause
The agenda block returned early before the past-time check.

## Fix
Short-circuit to reason="past" before agenda checks in the slots API.

## Tests
- Not run (logic-only change)
