### PR TITLE
[codex] minimal cookie banner

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -4,50 +4,26 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
     dispatchConsent,
-    getCookieConsent,
     hasStoredConsent,
     setCookieConsent,
-    COOKIE_CONSENT_EVENT,
     COOKIE_CONSENT_OPEN_EVENT,
     type CookieConsent,
 } from "@/lib/cookieConsent";
 
 export default function CookieBanner() {
     const [visible, setVisible] = useState(false);
-    const [prefsOpen, setPrefsOpen] = useState(false);
-    const [analyticsAllowed, setAnalyticsAllowed] = useState(false);
-    const [marketingAllowed, setMarketingAllowed] = useState(false);
 
     useEffect(() => {
-        const consent = getCookieConsent();
         setVisible(!hasStoredConsent());
-        setAnalyticsAllowed(consent?.analytics ?? false);
-        setMarketingAllowed(consent?.marketing ?? false);
     }, []);
 
     useEffect(() => {
         function onOpenPrefs() {
-            const consent = getCookieConsent();
-            setAnalyticsAllowed(consent?.analytics ?? false);
-            setMarketingAllowed(consent?.marketing ?? false);
             setVisible(true);
-            setPrefsOpen(true);
         }
 
         window.addEventListener(COOKIE_CONSENT_OPEN_EVENT, onOpenPrefs);
         return () => window.removeEventListener(COOKIE_CONSENT_OPEN_EVENT, onOpenPrefs);
-    }, []);
-
-    useEffect(() => {
-        function onConsent(event: Event) {
-            const detail = (event as CustomEvent<CookieConsent>).detail;
-            if (!detail) return;
-            setAnalyticsAllowed(detail.analytics);
-            setMarketingAllowed(detail.marketing);
-        }
-
-        window.addEventListener(COOKIE_CONSENT_EVENT, onConsent);
-        return () => window.removeEventListener(COOKIE_CONSENT_EVENT, onConsent);
     }, []);
 
     if (!visible) return null;
@@ -56,12 +32,21 @@ export default function CookieBanner() {
         setCookieConsent(consent);
         dispatchConsent(consent);
         setVisible(false);
-        setPrefsOpen(false);
     }
 
     return (
         <div className="cookieBanner" role="dialog" aria-label="Cookies">
-            <div className="cookieBannerInner">
+            <button
+                className="cookieBannerClose"
+                type="button"
+                aria-label="Rejeitar cookies"
+                onClick={() => {
+                    applyConsent({ analytics: false, marketing: false });
+                }}
+            >
+                ×
+            </button>
+            <div className="cookieBannerInner cookieBannerInner--compact">
                 <div className="cookieBannerText">
                     Usamos cookies essenciais e, com seu consentimento, cookies de análise e marketing para melhorar
                     sua experiência, medir resultados e oferecer conteúdos relevantes.
@@ -73,70 +58,17 @@ export default function CookieBanner() {
                     </span>
                 </div>
 
-                <div style={{ display: "flex", gap: 10, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                    <button
-                        className="cookieBannerButton"
-                        onClick={() => {
-                            setPrefsOpen((v) => !v);
-                        }}
-                    >
-                        Preferências
-                    </button>
-                    <button
-                        className="cookieBannerButton"
-                        onClick={() => {
-                            applyConsent({ analytics: false, marketing: false });
-                        }}
-                    >
-                        Rejeitar
-                    </button>
+                <div className="cookieBannerActions">
                     <button
                         className="cookieBannerButton"
                         onClick={() => {
                             applyConsent({ analytics: true, marketing: true });
                         }}
                     >
-                        Aceitar tudo
+                        Aceitar
                     </button>
                 </div>
             </div>
-
-            {prefsOpen ? (
-                <div className="cookieBannerInner" style={{ marginTop: 10 }}>
-                    <div className="cookieBannerText">
-                        <div style={{ fontWeight: 900, marginBottom: 6 }}>Preferências</div>
-                        <label style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                            <input
-                                type="checkbox"
-                                checked={analyticsAllowed}
-                                onChange={(e) => setAnalyticsAllowed(e.target.checked)}
-                            />
-                            Cookies de análise (ex.: GA4)
-                        </label>
-                        <label style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 8 }}>
-                            <input
-                                type="checkbox"
-                                checked={marketingAllowed}
-                                onChange={(e) => setMarketingAllowed(e.target.checked)}
-                            />
-                            Cookies de marketing/remarketing (ex.: Google Ads, Meta)
-                        </label>
-                        <div className="small" style={{ marginTop: 6 }}>
-                            Essenciais sempre ativos.
-                        </div>
-                    </div>
-                    <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", flexWrap: "wrap" }}>
-                        <button
-                            className="cookieBannerButton"
-                            onClick={() => {
-                                applyConsent({ analytics: analyticsAllowed, marketing: marketingAllowed });
-                            }}
-                        >
-                            Salvar
-                        </button>
-                    </div>
-                </div>
-            ) : null}
         </div>
     );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1975,11 +1975,11 @@ video.heroMediaEl {
   right: 0;
   bottom: 0;
   z-index: 70;
-  padding: 14px 14px;
-  background: rgba(10, 10, 10, .92);
+  padding: 10px 14px;
+  background: rgba(10, 10, 10, .82);
   color: #fff;
-  border-top: 1px solid rgba(255, 255, 255, .12);
-  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(255, 255, 255, .08);
+  backdrop-filter: blur(6px);
 }
 
 .cookieBannerInner {
@@ -1991,18 +1991,29 @@ video.heroMediaEl {
   justify-content: space-between;
 }
 
+.cookieBannerInner--compact {
+  padding-right: 28px;
+}
+
 .cookieBannerText {
-  font-size: 13px;
-  line-height: 1.35;
-  opacity: .95;
+  font-size: 12px;
+  line-height: 1.3;
+  opacity: .9;
   max-width: 820px;
+}
+
+.cookieBannerActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .cookieBannerButton {
   appearance: none;
   border: 0;
   border-radius: 999px;
-  padding: 10px 14px;
+  padding: 8px 12px;
   font-weight: 800;
   cursor: pointer;
   background: #ffffff;
@@ -2011,6 +2022,25 @@ video.heroMediaEl {
 
 .cookieBannerButton:hover {
   background: #f3f3f3;
+}
+
+.cookieBannerClose {
+  position: absolute;
+  top: 6px;
+  right: 10px;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 0;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 16px;
+  line-height: 20px;
+  cursor: pointer;
+}
+
+.cookieBannerClose:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 @media (max-width:900px) {
@@ -2090,6 +2120,10 @@ video.heroMediaEl {
 
   .cookieBannerButton {
     width: 100%
+  }
+
+  .cookieBannerInner--compact {
+    padding-right: 0;
   }
 
   .footerInner {


### PR DESCRIPTION
## Summary
Make the cookie banner minimal: one “Aceitar” button, a small “x” that acts as reject, and a lighter, less intrusive style.

## Problem
The banner was visually heavy and had multiple buttons and a preferences panel.

## Fix
- Remove preferences UI and extra buttons.
- Add a small close “x” that rejects cookies.
- Keep a single “Aceitar” (accept all) button.
- Reduce visual weight (smaller text, lighter background, tighter padding).

## Tests
- `npm run lint`
