### PR TITLE
[codex] Modal do Instagram com feed paginado interno, retry e cache

### DIFF
--- a/src/app/api/instagram-feed/route.ts
+++ b/src/app/api/instagram-feed/route.ts
@@ -1,0 +1,300 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const INSTAGRAM_APP_ID = "936619743392459";
+const FEED_PAGE_SIZE = 12;
+const MAX_FETCH_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 250;
+
+type InstagramProfileResponse = {
+    data?: {
+        user?: {
+            id?: string;
+            username?: string;
+            full_name?: string;
+            biography?: string;
+        };
+    };
+};
+
+type InstagramProfileUser = NonNullable<InstagramProfileResponse["data"]>["user"];
+
+type CfCacheStorage = {
+    default?: Cache;
+};
+
+type InstagramFeedImageCandidate = {
+    url?: string;
+    width?: number;
+    height?: number;
+};
+
+type InstagramFeedVideoVersion = {
+    url?: string;
+    width?: number;
+    height?: number;
+};
+
+type InstagramFeedItem = {
+    id?: string;
+    pk?: string;
+    code?: string;
+    media_type?: number;
+    product_type?: string;
+    taken_at?: number;
+    caption?: { text?: string | null } | null;
+    image_versions2?: { candidates?: InstagramFeedImageCandidate[] } | null;
+    video_versions?: InstagramFeedVideoVersion[] | null;
+    carousel_media?: InstagramFeedItem[] | null;
+};
+
+type InstagramFeedResponse = {
+    items?: InstagramFeedItem[];
+    more_available?: boolean;
+    next_max_id?: string | null;
+};
+
+type NormalizedInstagramMedia = {
+    id: string;
+    code: string | null;
+    mediaType: "image" | "video" | "carousel";
+    isReel: boolean;
+    caption: string | null;
+    takenAtMs: number | null;
+    thumbnailUrl: string;
+    videoUrl: string | null;
+};
+
+function sanitizeHandle(input: string): string {
+    return (input ?? "").trim().replace(/^@/, "").replace(/[^a-zA-Z0-9._]/g, "").toLowerCase();
+}
+
+function sanitizeUserId(input: string): string {
+    return (input ?? "").trim().replace(/[^0-9]/g, "");
+}
+
+function sanitizeCursor(input: string): string {
+    return (input ?? "").trim().slice(0, 500);
+}
+
+function instagramRequestHeaders(): HeadersInit {
+    return {
+        "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        accept: "application/json,text/plain,*/*",
+        "accept-language": "pt-BR,pt;q=0.9,en;q=0.8",
+        "x-ig-app-id": INSTAGRAM_APP_ID,
+        origin: "https://www.instagram.com",
+        referer: "https://www.instagram.com/",
+    };
+}
+
+function getCloudflareCache(): Cache | null {
+    const cachesAny = (globalThis as unknown as { caches?: CfCacheStorage }).caches;
+    return cachesAny?.default ?? null;
+}
+
+function isRetryableStatus(status: number): boolean {
+    return status === 429 || status >= 500;
+}
+
+async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchInstagramJson<T>(url: string): Promise<T | null> {
+    for (let attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt++) {
+        try {
+            const res = await fetch(url, {
+                redirect: "follow",
+                headers: instagramRequestHeaders(),
+                next: { revalidate: 60 * 5 },
+            });
+
+            if (!res.ok) {
+                if (attempt < MAX_FETCH_ATTEMPTS - 1 && isRetryableStatus(res.status)) {
+                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                    continue;
+                }
+                return null;
+            }
+
+            const raw = await res.text();
+            const cleaned = raw.replace(/^for \(;;\);\s*/, "");
+
+            try {
+                return JSON.parse(cleaned) as T;
+            } catch {
+                if (attempt < MAX_FETCH_ATTEMPTS - 1) {
+                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                    continue;
+                }
+                return null;
+            }
+        } catch {
+            if (attempt < MAX_FETCH_ATTEMPTS - 1) {
+                await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                continue;
+            }
+            return null;
+        }
+    }
+    return null;
+}
+
+async function fetchProfile(handle: string): Promise<InstagramProfileUser | null> {
+    const url = `https://www.instagram.com/api/v1/users/web_profile_info/?username=${encodeURIComponent(handle)}`;
+    const json = await fetchInstagramJson<InstagramProfileResponse>(url);
+    return json?.data?.user ?? null;
+}
+
+async function fetchFeed(params: { userId: string; cursor?: string | null; count?: number }): Promise<InstagramFeedResponse | null> {
+    const url = new URL(`https://www.instagram.com/api/v1/feed/user/${encodeURIComponent(params.userId)}/`);
+    url.searchParams.set("count", String(params.count ?? FEED_PAGE_SIZE));
+    if (params.cursor) url.searchParams.set("max_id", params.cursor);
+    return fetchInstagramJson<InstagramFeedResponse>(url.toString());
+}
+
+function pickLargestImage(candidates: InstagramFeedImageCandidate[] | null | undefined): string | null {
+    if (!Array.isArray(candidates) || candidates.length === 0) return null;
+    const sorted = [...candidates].sort((a, b) => {
+        const areaA = (a.width ?? 0) * (a.height ?? 0);
+        const areaB = (b.width ?? 0) * (b.height ?? 0);
+        return areaB - areaA;
+    });
+    const best = sorted[0];
+    return typeof best?.url === "string" ? best.url : null;
+}
+
+function pickLargestVideo(versions: InstagramFeedVideoVersion[] | null | undefined): string | null {
+    if (!Array.isArray(versions) || versions.length === 0) return null;
+    const sorted = [...versions].sort((a, b) => {
+        const areaA = (a.width ?? 0) * (a.height ?? 0);
+        const areaB = (b.width ?? 0) * (b.height ?? 0);
+        return areaB - areaA;
+    });
+    const best = sorted[0];
+    return typeof best?.url === "string" ? best.url : null;
+}
+
+function normalizeItem(item: InstagramFeedItem): NormalizedInstagramMedia | null {
+    const code = typeof item.code === "string" && item.code.trim() ? item.code.trim() : null;
+    const id = `${item.id ?? item.pk ?? code ?? ""}`.trim();
+    if (!id) return null;
+
+    const mediaTypeNumber = item.media_type ?? 1;
+    const isCarousel = mediaTypeNumber === 8;
+    const isVideo = mediaTypeNumber === 2;
+
+    let imageUrl = pickLargestImage(item.image_versions2?.candidates);
+    let videoUrl = pickLargestVideo(item.video_versions);
+
+    if (isCarousel && Array.isArray(item.carousel_media) && item.carousel_media.length > 0) {
+        const first = item.carousel_media[0];
+        imageUrl = imageUrl ?? pickLargestImage(first?.image_versions2?.candidates);
+        if (!videoUrl) videoUrl = pickLargestVideo(first?.video_versions);
+    }
+
+    if (!imageUrl && !videoUrl) return null;
+
+    return {
+        id,
+        code,
+        mediaType: isCarousel ? "carousel" : isVideo ? "video" : "image",
+        isReel: item.product_type === "clips",
+        caption: typeof item.caption?.text === "string" && item.caption.text.trim() ? item.caption.text.trim() : null,
+        takenAtMs: typeof item.taken_at === "number" ? item.taken_at * 1000 : null,
+        thumbnailUrl: imageUrl ?? videoUrl ?? "",
+        videoUrl: videoUrl ?? null,
+    };
+}
+
+export async function GET(req: Request) {
+    const { searchParams } = new URL(req.url);
+    const handle = sanitizeHandle(searchParams.get("handle") ?? "");
+    const cursor = sanitizeCursor(searchParams.get("cursor") ?? "");
+    let userId = sanitizeUserId(searchParams.get("userId") ?? "");
+
+    if (!handle) {
+        return NextResponse.json({ ok: false, error: "invalid_handle" }, { status: 400 });
+    }
+
+    try {
+        const cache = getCloudflareCache();
+        const cacheKey = new Request(
+            `https://espacofacial.com/__cache/instagram-feed?handle=${encodeURIComponent(handle)}&userId=${encodeURIComponent(userId)}&cursor=${encodeURIComponent(cursor)}`,
+        );
+        if (cache) {
+            const cached = await cache.match(cacheKey);
+            if (cached) {
+                const payload = await cached.text();
+                return new NextResponse(payload, {
+                    status: 200,
+                    headers: {
+                        "content-type": "application/json; charset=utf-8",
+                        "cache-control": cached.headers.get("cache-control") ?? "public, max-age=60, s-maxage=300",
+                        "x-instagram-feed-source": "cache",
+                    },
+                });
+            }
+        }
+
+        let profile: InstagramProfileUser | null = null;
+        if (!userId) {
+            profile = await fetchProfile(handle);
+            userId = sanitizeUserId(profile?.id ?? "");
+        }
+
+        if (!userId) {
+            return NextResponse.json({ ok: false, error: "profile_not_found" }, { status: 404 });
+        }
+
+        const feed = await fetchFeed({ userId, cursor: cursor || null, count: FEED_PAGE_SIZE });
+        if (!feed) {
+            return NextResponse.json({ ok: false, error: "feed_unavailable" }, { status: 502 });
+        }
+
+        const items = (feed.items ?? []).map(normalizeItem).filter((v): v is NormalizedInstagramMedia => !!v);
+        const nextCursor = typeof feed.next_max_id === "string" && feed.next_max_id.trim() ? feed.next_max_id : null;
+        const hasMore = Boolean(feed.more_available && nextCursor);
+
+        const responseBody = {
+            ok: true,
+            user: {
+                id: userId,
+                handle: profile?.username ?? handle,
+                name: profile?.full_name ?? null,
+                bio: profile?.biography ?? null,
+            },
+            items,
+            hasMore,
+            nextCursor,
+        };
+
+        const payload = JSON.stringify(responseBody);
+        if (cache) {
+            await cache.put(
+                cacheKey,
+                new Response(payload, {
+                    status: 200,
+                    headers: {
+                        "content-type": "application/json; charset=utf-8",
+                        "cache-control": "public, max-age=60, s-maxage=300",
+                    },
+                }),
+            );
+        }
+
+        return new NextResponse(payload, {
+            status: 200,
+            headers: {
+                "content-type": "application/json; charset=utf-8",
+                "cache-control": "public, max-age=60, s-maxage=300",
+                "x-instagram-feed-source": "origin",
+            },
+        });
+    } catch {
+        return NextResponse.json({ ok: false, error: "instagram_feed_error" }, { status: 500 });
+    }
+}

--- a/src/components/UnitDoctorsGrid.tsx
+++ b/src/components/UnitDoctorsGrid.tsx
@@ -18,6 +18,63 @@ type TeamMember = {
     instagramUrl: string | null;
 };
 
+type InstagramMedia = {
+    id: string;
+    code: string | null;
+    mediaType: "image" | "video" | "carousel";
+    isReel: boolean;
+    caption: string | null;
+    takenAtMs: number | null;
+    thumbnailUrl: string;
+    videoUrl: string | null;
+};
+
+type InstagramFeedResponse =
+    | {
+          ok: true;
+          user: { id: string; handle: string; name: string | null; bio: string | null };
+          items: InstagramMedia[];
+          hasMore: boolean;
+          nextCursor: string | null;
+      }
+    | { ok: false; error: string };
+
+async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchInstagramFeed(params: {
+    handle: string;
+    userId?: string | null;
+    cursor?: string | null;
+    attempts?: number;
+}): Promise<InstagramFeedResponse | null> {
+    const attempts = Math.max(1, params.attempts ?? 3);
+    for (let i = 0; i < attempts; i++) {
+        try {
+            const qs = new URLSearchParams({ handle: params.handle });
+            if (params.userId) qs.set("userId", params.userId);
+            if (params.cursor) qs.set("cursor", params.cursor);
+            const res = await fetch(`/api/instagram-feed?${qs.toString()}`, { cache: "no-store" });
+            const json = (await res.json().catch(() => null)) as InstagramFeedResponse | null;
+            if (json && json.ok) return json;
+
+            if (i < attempts - 1) {
+                await sleep(250 * (i + 1));
+                continue;
+            }
+            return json;
+        } catch {
+            if (i < attempts - 1) {
+                await sleep(250 * (i + 1));
+                continue;
+            }
+            return null;
+        }
+    }
+    return null;
+}
+
 function instagramIcon() {
     return (
         <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -64,12 +121,6 @@ function extractInstagramHandle(url: string | null): string | null {
     }
 }
 
-function instagramEmbedUrl(handle: string | null, url: string | null): string | null {
-    const resolved = handle || extractInstagramHandle(url);
-    if (!resolved) return null;
-    return `https://www.instagram.com/${resolved}/embed`;
-}
-
 export default function UnitDoctorsGrid() {
     const unit = useCurrentUnit();
     const unitLabel = unitLabelFromSlug(unit?.slug);
@@ -78,9 +129,17 @@ export default function UnitDoctorsGrid() {
     const [membersError, setMembersError] = useState<string | null>(null);
     const [activeInstagram, setActiveInstagram] = useState<{
         name: string;
-        handle: string | null;
-        url: string;
+        handle: string;
     } | null>(null);
+    const [instagramItems, setInstagramItems] = useState<InstagramMedia[]>([]);
+    const [instagramUserId, setInstagramUserId] = useState<string | null>(null);
+    const [instagramNextCursor, setInstagramNextCursor] = useState<string | null>(null);
+    const [instagramHasMore, setInstagramHasMore] = useState(false);
+    const [instagramLoading, setInstagramLoading] = useState(false);
+    const [instagramLoadingMore, setInstagramLoadingMore] = useState(false);
+    const [instagramError, setInstagramError] = useState<string | null>(null);
+    const [activeInstagramMediaId, setActiveInstagramMediaId] = useState<string | null>(null);
+    const [instagramReloadToken, setInstagramReloadToken] = useState(0);
 
     useEffect(() => {
         let cancelled = false;
@@ -112,12 +171,17 @@ export default function UnitDoctorsGrid() {
         if (!activeInstagram) return;
 
         function onKeyDown(e: KeyboardEvent) {
-            if (e.key === "Escape") setActiveInstagram(null);
+            if (e.key !== "Escape") return;
+            if (activeInstagramMediaId) {
+                setActiveInstagramMediaId(null);
+                return;
+            }
+            setActiveInstagram(null);
         }
 
         document.addEventListener("keydown", onKeyDown);
         return () => document.removeEventListener("keydown", onKeyDown);
-    }, [activeInstagram]);
+    }, [activeInstagram, activeInstagramMediaId]);
 
     const filtered = useMemo(() => {
         if (!members) return null;
@@ -126,10 +190,90 @@ export default function UnitDoctorsGrid() {
         return members.filter((m) => m.units.map((u) => u.toLowerCase()).includes(unitLabel.toLowerCase()));
     }, [members, unitLabel]);
 
-    const activeInstagramEmbed = useMemo(() => {
-        if (!activeInstagram) return null;
-        return instagramEmbedUrl(activeInstagram.handle, activeInstagram.url);
-    }, [activeInstagram]);
+    useEffect(() => {
+        if (!activeInstagram) return;
+        const currentInstagram = activeInstagram;
+        let cancelled = false;
+
+        async function loadInstagramFeed() {
+            setInstagramLoading(true);
+            setInstagramLoadingMore(false);
+            setInstagramError(null);
+            setInstagramItems([]);
+            setInstagramUserId(null);
+            setInstagramNextCursor(null);
+            setInstagramHasMore(false);
+            setActiveInstagramMediaId(null);
+
+            try {
+                const json = await fetchInstagramFeed({ handle: currentInstagram.handle, attempts: 3 });
+                if (cancelled) return;
+                if (!json || !json.ok) {
+                    setInstagramError("Não foi possível carregar as publicações agora.");
+                    return;
+                }
+
+                setInstagramItems(Array.isArray(json.items) ? json.items : []);
+                setInstagramUserId(json.user?.id || null);
+                setInstagramNextCursor(json.nextCursor ?? null);
+                setInstagramHasMore(Boolean(json.hasMore && json.nextCursor));
+            } catch {
+                if (cancelled) return;
+                setInstagramError("Falha de rede ao carregar publicações.");
+            } finally {
+                if (!cancelled) setInstagramLoading(false);
+            }
+        }
+
+        loadInstagramFeed();
+        return () => {
+            cancelled = true;
+        };
+    }, [activeInstagram, instagramReloadToken]);
+
+    const activeInstagramMediaIndex = useMemo(() => {
+        if (!activeInstagramMediaId) return -1;
+        return instagramItems.findIndex((item) => item.id === activeInstagramMediaId);
+    }, [activeInstagramMediaId, instagramItems]);
+
+    const activeInstagramMedia = useMemo(() => {
+        if (activeInstagramMediaIndex < 0) return null;
+        return instagramItems[activeInstagramMediaIndex] ?? null;
+    }, [activeInstagramMediaIndex, instagramItems]);
+
+    const hasPrevInstagramMedia = activeInstagramMediaIndex > 0;
+    const hasNextInstagramMedia = activeInstagramMediaIndex >= 0 && activeInstagramMediaIndex < instagramItems.length - 1;
+
+    async function loadMoreInstagram() {
+        if (!activeInstagram || !instagramUserId || !instagramNextCursor || instagramLoadingMore) return;
+
+        setInstagramLoadingMore(true);
+        setInstagramError(null);
+        try {
+            const json = await fetchInstagramFeed({
+                handle: activeInstagram.handle,
+                userId: instagramUserId,
+                cursor: instagramNextCursor,
+                attempts: 3,
+            });
+            if (!json || !json.ok) {
+                setInstagramError("Não foi possível carregar mais publicações.");
+                return;
+            }
+
+            setInstagramItems((prev) => {
+                const seen = new Set(prev.map((item) => item.id));
+                const nextItems = json.items.filter((item) => !seen.has(item.id));
+                return [...prev, ...nextItems];
+            });
+            setInstagramNextCursor(json.nextCursor ?? null);
+            setInstagramHasMore(Boolean(json.hasMore && json.nextCursor));
+        } catch {
+            setInstagramError("Falha de rede ao carregar mais publicações.");
+        } finally {
+            setInstagramLoadingMore(false);
+        }
+    }
 
     if (!unitLabel) {
         return (
@@ -177,12 +321,12 @@ export default function UnitDoctorsGrid() {
                         ? `/agendamento?unit=${encodeURIComponent(unit.slug)}&doctor=${encodeURIComponent(doctorSlug)}`
                         : "/agendamento";
                     const openInstagram = () => {
-                        if (!href) return;
-                        setActiveInstagram({ name: fullName, handle: instagramHandle, url: href });
+                        if (!instagramHandle) return;
+                        setActiveInstagram({ name: fullName, handle: instagramHandle });
                         trackDoctorInstagramClick({
                             unitSlug: unit?.slug ?? null,
                             doctorName: fullName,
-                            instagramUrl: href,
+                            instagramUrl: href ?? `https://www.instagram.com/${instagramHandle}/`,
                         });
                     };
 
@@ -193,7 +337,7 @@ export default function UnitDoctorsGrid() {
                             style={{ display: "block" }}
                         >
                             <div style={{ display: "flex", gap: 12, alignItems: "center", justifyContent: "space-between" }}>
-                                {href ? (
+                                {instagramHandle ? (
                                     <button
                                         className="doctorCardMainLink doctorCardMainButton"
                                         type="button"
@@ -230,7 +374,7 @@ export default function UnitDoctorsGrid() {
                                 )}
 
                                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
-                                    {href ? (
+                                    {instagramHandle ? (
                                         <button
                                             className="iconBtn"
                                             type="button"
@@ -279,27 +423,132 @@ export default function UnitDoctorsGrid() {
                         <div className="modalHeader">
                             <div>
                                 <div className="modalTitle">{activeInstagram.name}</div>
-                                {activeInstagram.handle ? <div className="modalSubtitle">@{activeInstagram.handle}</div> : null}
+                                <div className="modalSubtitle">@{activeInstagram.handle}</div>
                             </div>
                             <button className="modalClose" type="button" onClick={() => setActiveInstagram(null)} aria-label="Fechar">
                                 ×
                             </button>
                         </div>
                         <div className="modalBody instagramModalBody">
-                            {activeInstagramEmbed ? (
-                                <iframe
-                                    className="instagramFrame"
-                                    title={`Instagram - ${activeInstagram.name}`}
-                                    src={activeInstagramEmbed}
-                                    loading="lazy"
-                                    referrerPolicy="no-referrer"
-                                />
-                            ) : (
+                            {instagramLoading && instagramItems.length === 0 ? (
                                 <div className="instagramFallback">
-                                    Não foi possível carregar o Instagram aqui. Tente novamente mais tarde.
+                                    Carregando publicações e reels…
                                 </div>
-                            )}
-                            <div className="modalNote">O conteúdo é exibido em uma janela interna para manter você no site.</div>
+                            ) : null}
+
+                            {!instagramLoading && instagramItems.length === 0 ? (
+                                <div className="instagramFallback">
+                                    {instagramError ? "Não foi possível carregar o Instagram agora. Tente novamente em instantes." : "Nenhuma publicação visível neste perfil no momento."}
+                                    {instagramError ? (
+                                        <div className="modalActions">
+                                            <button
+                                                className="btn btnGhost instagramLoadMoreBtn"
+                                                type="button"
+                                                onClick={() => setInstagramReloadToken((v) => v + 1)}
+                                                disabled={instagramLoading}
+                                            >
+                                                Tentar novamente
+                                            </button>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            ) : null}
+
+                            {activeInstagramMedia ? (
+                                <div className="instagramViewer">
+                                    <div className="instagramViewerTop">
+                                        <button className="btn btnGhost instagramViewerBack" type="button" onClick={() => setActiveInstagramMediaId(null)}>
+                                            Voltar ao grid
+                                        </button>
+                                        <div className="instagramViewerNav">
+                                            <button
+                                                className="btn btnGhost instagramViewerStep"
+                                                type="button"
+                                                disabled={!hasPrevInstagramMedia}
+                                                onClick={() => {
+                                                    if (!hasPrevInstagramMedia) return;
+                                                    setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex - 1]?.id ?? null);
+                                                }}
+                                            >
+                                                Anterior
+                                            </button>
+                                            <button
+                                                className="btn btnGhost instagramViewerStep"
+                                                type="button"
+                                                disabled={!hasNextInstagramMedia}
+                                                onClick={() => {
+                                                    if (!hasNextInstagramMedia) return;
+                                                    setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex + 1]?.id ?? null);
+                                                }}
+                                            >
+                                                Próximo
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <div className="instagramViewerMediaWrap">
+                                        {activeInstagramMedia.mediaType === "video" && activeInstagramMedia.videoUrl ? (
+                                            <video
+                                                className="instagramViewerMedia"
+                                                src={activeInstagramMedia.videoUrl}
+                                                poster={activeInstagramMedia.thumbnailUrl}
+                                                controls
+                                                playsInline
+                                                preload="metadata"
+                                            />
+                                        ) : (
+                                            <img className="instagramViewerMedia" src={activeInstagramMedia.thumbnailUrl} alt={`Publicação de ${activeInstagram.name}`} loading="lazy" />
+                                        )}
+                                    </div>
+
+                                    {activeInstagramMedia.caption ? <p className="instagramViewerCaption">{activeInstagramMedia.caption}</p> : null}
+                                </div>
+                            ) : null}
+
+                            {instagramItems.length > 0 ? (
+                                <div className="instagramGrid">
+                                    {instagramItems.map((item) => {
+                                        const label = item.isReel ? "Reel" : item.mediaType === "video" ? "Vídeo" : item.mediaType === "carousel" ? "Carrossel" : "Post";
+                                        return (
+                                            <button
+                                                key={item.id}
+                                                type="button"
+                                                className={`instagramMediaBtn ${activeInstagramMediaId === item.id ? "instagramMediaBtn--active" : ""}`.trim()}
+                                                onClick={() => setActiveInstagramMediaId(item.id)}
+                                                aria-label={`Abrir ${label.toLowerCase()} de ${activeInstagram.name}`}
+                                            >
+                                                <img className="instagramMediaThumb" src={item.thumbnailUrl} alt={`Publicação de ${activeInstagram.name}`} loading="lazy" />
+                                                {label !== "Post" ? <span className="instagramMediaBadge">{label}</span> : null}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            ) : null}
+
+                            {instagramError && instagramItems.length > 0 ? (
+                                <div className="instagramInlineError">
+                                    {instagramError}
+                                    <div className="modalActions">
+                                        <button
+                                            className="btn btnGhost instagramLoadMoreBtn"
+                                            type="button"
+                                            onClick={() => setInstagramReloadToken((v) => v + 1)}
+                                            disabled={instagramLoading}
+                                        >
+                                            Recarregar feed
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            {instagramHasMore ? (
+                                <div className="modalActions">
+                                    <button className="btn btnGhost instagramLoadMoreBtn" type="button" onClick={loadMoreInstagram} disabled={instagramLoadingMore}>
+                                        {instagramLoadingMore ? "Carregando…" : "Carregar mais"}
+                                    </button>
+                                </div>
+                            ) : null}
+                            <div className="modalNote">Posts e reels são exibidos dentro desta janela para manter você no site.</div>
                         </div>
                     </div>
                 </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1214,20 +1214,114 @@ video.heroMediaEl {
   gap: 12px;
 }
 
-.instagramFrame {
-  width: 100%;
-  height: 520px;
-  border: 0;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.04);
-}
-
 .instagramFallback {
   padding: 16px;
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.06);
   font-size: 14px;
+}
+
+.instagramGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.instagramMediaBtn {
+  position: relative;
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 12px;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+}
+
+.instagramMediaBtn--active {
+  border-color: rgba(255, 255, 255, 0.65);
+}
+
+.instagramMediaThumb {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.instagramMediaBadge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.58);
+}
+
+.instagramViewer {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.instagramViewerTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.instagramViewerNav {
+  display: flex;
+  gap: 8px;
+}
+
+.instagramViewerBack,
+.instagramViewerStep,
+.instagramLoadMoreBtn {
+  appearance: none;
+  cursor: pointer;
+}
+
+.instagramViewerStep:disabled,
+.instagramLoadMoreBtn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.instagramViewerMediaWrap {
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.instagramViewerMedia {
+  display: block;
+  width: 100%;
+  max-height: 64vh;
+  object-fit: contain;
+  background: #0c0c0d;
+}
+
+.instagramViewerCaption {
+  margin: 10px 2px 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.86);
+  white-space: pre-wrap;
+}
+
+.instagramInlineError {
+  font-size: 13px;
+  color: rgba(255, 210, 210, 0.95);
 }
 
 .modalActions {
@@ -1287,8 +1381,8 @@ video.heroMediaEl {
     height: 300px;
   }
 
-  .instagramFrame {
-    height: 420px;
+  .instagramGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -1970,62 +2064,59 @@ video.heroMediaEl {
 }
 
 .unitsFeatured {
-  border-radius: 18px;
-  padding: 14px;
-  background: linear-gradient(135deg, rgba(22, 163, 74, .16), rgba(22, 163, 74, .04));
-  border: 1px solid rgba(22, 163, 74, .35);
-  box-shadow: 0 12px 26px rgba(22, 163, 74, .18);
+  border: 1px solid rgba(0, 0, 0, .08);
+  border-radius: 16px;
+  padding: 10px;
+  background: #fafafa;
   margin-bottom: 12px;
 }
 
 .unitsFeaturedTitle {
   font-weight: 900;
-  font-size: 14px;
-  letter-spacing: 0.02em;
-  color: #0b0b0b;
-  margin-bottom: 10px;
+  font-size: 13px;
+  padding: 6px 8px;
+  margin-bottom: 8px;
 }
 
 .unitsFeaturedList {
   display: grid;
-  gap: 10px;
+  gap: 8px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .unitsFeaturedItem {
   appearance: none;
-  border: 0;
-  background: linear-gradient(140deg, #16a34a, #22c55e);
-  color: #fff;
-  border-radius: 999px;
-  padding: 12px 14px;
+  border: 1px solid rgba(0, 0, 0, .10);
+  background: #fff;
+  color: var(--text);
+  border-radius: 12px;
+  padding: 9px 10px;
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 900;
-  font-size: 14px;
-  letter-spacing: 0.02em;
-  justify-content: flex-start;
-  box-shadow: 0 12px 26px rgba(22, 163, 74, .3);
+  gap: 8px;
+  font-weight: 800;
+  font-size: 13px;
+  text-align: left;
 }
 
 .unitsFeaturedItem:hover {
-  background: linear-gradient(140deg, #0f172a, #16a34a);
+  background: #f3f3f3;
 }
 
 .unitsFeaturedItemTag {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  padding: 6px 10px;
+  min-width: 32px;
+  padding: 3px 7px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, .22);
-  color: #fff;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  border: 1px solid rgba(255, 255, 255, .5);
+  border: 1px solid rgba(0, 0, 0, .12);
+  background: #fff;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
 }
 
 .unitsFeaturedItemName {


### PR DESCRIPTION
## Contexto e impacto para usuários
Na seção **Nossos Doutores**, o modal anterior usava `iframe` do perfil do Instagram. Isso causava duas limitações de UX:
1. o conteúdo carregava apenas uma amostra pequena (na prática, poucos itens iniciais);
2. ao interagir com o conteúdo, o usuário acabava saindo do fluxo do site e sendo levado para fora.

Na prática, a jornada de descoberta de conteúdo do doutor era interrompida, com perda de contexto para o agendamento.

## Causa raiz
O embed de perfil do Instagram não oferece um feed navegável completo controlado pela aplicação, nem um visualizador interno com paginação e navegação de mídia sob controle do frontend.

## Solução implementada
A solução substitui o embed de perfil por um feed próprio, carregado via backend, e renderizado em um modal interno:

- **Novo endpoint** `GET /api/instagram-feed`
  - Resolve perfil por `handle` e busca mídia paginada (posts/reels) usando endpoints web do Instagram.
  - Normaliza os itens retornados para um formato simples de UI.
  - Suporta paginação por `cursor`.
  - Inclui **retry com backoff** para respostas transitórias (429/5xx e erros de rede).
  - Inclui **cache de borda (Cloudflare cache API)** por chave `handle + userId + cursor`, reduzindo chamadas repetidas e risco de rate limit.

- **Modal da página de doutores** (`UnitDoctorsGrid`)
  - Abre feed interno em grade, sem redirecionamento externo.
  - Permite **Carregar mais** para expandir o conteúdo além dos primeiros itens.
  - Clique em item abre **viewer interno** (imagem/vídeo) com navegação `Anterior/Próximo`.
  - Tecla `Esc` fecha primeiro o viewer e depois o modal.
  - Inclui **retry automático no cliente** e ações manuais `Tentar novamente` / `Recarregar feed` quando houver falha.

- **Estilos**
  - Adicionados estilos do grid de mídia, badges de tipo (Reel/Vídeo/Carrossel), viewer interno e estados de erro/reload, mantendo comportamento responsivo.

## Arquivos alterados
- `src/app/api/instagram-feed/route.ts`
- `src/components/UnitDoctorsGrid.tsx`
- `src/styles/globals.css`

## Validação executada
- `npm run -s typecheck` ✅
- `npm run -s lint` ✅ (com warnings já conhecidos sobre uso de `<img>` em componentes)

## Resultado esperado
- Usuário permanece no site durante toda a exploração de posts/reels dos doutores.
- Conteúdo não fica limitado aos poucos itens iniciais, graças à paginação interna.
- Fluxo fica mais resiliente contra instabilidades do Instagram por causa de retry + cache.
