### PR TITLE
[codex] align booking rails and defaults

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -351,7 +351,8 @@ export default function BookingFlow() {
     }, [allowedUnitSlugs, currentUnit?.slug]);
 
     const primaryService = selectedServices[0] ?? null;
-    const primaryServiceId = primaryService?.id ?? null;
+    const effectivePrimaryService = primaryService ?? OTHER_SERVICE;
+    const effectiveServiceId = effectivePrimaryService.id;
     const selectedServiceIds = useMemo(() => selectedServices.map((item) => item.id), [selectedServices]);
     const selectedServiceNames = useMemo(() => selectedServices.map((item) => item.name), [selectedServices]);
     const selectedServicesLabel = useMemo(() => selectedServiceNames.join(", "), [selectedServiceNames]);
@@ -522,7 +523,7 @@ export default function BookingFlow() {
 
         async function loadDateAvailability() {
             setDateAvailability({});
-            const serviceId = primaryServiceId;
+            const serviceId = effectiveServiceId;
 
             if (!unitSlug || durationMinutes <= 0 || !serviceId) return;
 
@@ -559,14 +560,14 @@ export default function BookingFlow() {
         return () => {
             cancelled = true;
         };
-    }, [durationMinutes, effectiveDoctorSlug, primaryServiceId, unitSlug, upcomingDays]);
+    }, [durationMinutes, effectiveDoctorSlug, effectiveServiceId, unitSlug, upcomingDays]);
 
     useEffect(() => {
         async function loadSlots() {
             setSlots(null);
             setSlotsError(null);
             setSlotsLoading(false);
-            const serviceId = primaryServiceId;
+            const serviceId = effectiveServiceId;
 
             if (!unitSlug || !dateKey || durationMinutes <= 0 || !serviceId) return;
 
@@ -601,7 +602,7 @@ export default function BookingFlow() {
         }
 
         loadSlots();
-    }, [dateKey, durationMinutes, effectiveDoctorSlug, primaryServiceId, unitSlug]);
+    }, [dateKey, durationMinutes, effectiveDoctorSlug, effectiveServiceId, unitSlug]);
 
     async function submit() {
         setSubmitError(null);
@@ -775,7 +776,7 @@ export default function BookingFlow() {
     }, [submitted]);
 
     const canPickProcedure = !!unitSlug;
-    const canPick = !!unitSlug && selectedServices.length > 0;
+    const canPick = !!unitSlug;
     const hasResolvedDateAvailability = upcomingDays.every((day) => typeof dateAvailability[day] === "boolean");
     const visibleUpcomingWeeks = useMemo(() => {
         if (!canPick || !hasResolvedDateAvailability) return upcomingWeeks.slice(0, 4);
@@ -809,7 +810,13 @@ export default function BookingFlow() {
         return slots.slots.find((s) => s.time === timeKey) ?? null;
     }, [slots?.slots, timeKey]);
 
+    function ensureDefaultSelections() {
+        if (!doctor) setDoctor(ANY_DOCTOR);
+        if (selectedServices.length === 0) setSelectedServices([OTHER_SERVICE]);
+    }
+
     function openDetailsModal(nextTime: string) {
+        ensureDefaultSelections();
         setTimeKey(nextTime);
         setStep("details");
         setDetailsStage("contact");
@@ -821,7 +828,7 @@ export default function BookingFlow() {
             step: "details_opened",
             unitSlug,
             doctorSlug: effectiveDoctorSlug,
-            serviceId: primaryService?.id ?? null,
+            serviceId: effectiveServiceId,
             date: dateKey,
             time: nextTime,
             detailsStage: "contact",
@@ -997,7 +1004,7 @@ export default function BookingFlow() {
 
                     <div
                         className={`card bookingFlow__cardDoctor ${unitSlug ? "bookingFlow__cardDoctor--half" : "bookingFlow__cardDoctor--withUnit"}`.trim()}
-                        style={{ padding: 16 }}
+                        style={{ padding: 14 }}
                     >
                         <div className="bookingFlow__entryTitle">Escolha o seu doutor</div>
                         {unit ? (
@@ -1006,7 +1013,7 @@ export default function BookingFlow() {
                             </div>
                         ) : null}
                         <div className="bookingFlow__cardSub">Clique e selecione um de nossos doutores para o seu atendimento.</div>
-                        <div style={{ marginTop: 10 }}>
+                        <div style={{ marginTop: 6 }}>
                             {!unitLabel ? (
                                 <div className="small bookingFlow__unitStatus bookingFlow__unitStatus--error" role="status">
                                     Selecione a unidade para liberar os doutores.
@@ -1024,7 +1031,7 @@ export default function BookingFlow() {
                             ) : (
                                 <HoverScrollPicker
                                     ariaLabel="Lista de profissionais"
-                                    className="bookingFlow__picker--bleed bookingFlow__picker--doctor"
+                                    className="bookingFlow__picker--bleed bookingFlow__picker--rail bookingFlow__picker--doctor"
                                     scrollWindowClassName="bookingFlow__scrollWindow--doctor"
                                 >
                                     <div className="bookingFlow__doctorBadgeGrid">
@@ -1111,7 +1118,7 @@ export default function BookingFlow() {
                         </div>
                     </div>
 
-                    <div className={`card bookingFlow__cardProcedure ${unitSlug ? "bookingFlow__cardProcedure--half" : "bookingFlow__cardProcedure--full"} ${canPickProcedure ? "" : "bookingFlow__card--locked"}`.trim()} style={{ padding: 16 }}>
+                    <div className={`card bookingFlow__cardProcedure ${unitSlug ? "bookingFlow__cardProcedure--half" : "bookingFlow__cardProcedure--full"} ${canPickProcedure ? "" : "bookingFlow__card--locked"}`.trim()} style={{ padding: 14 }}>
                         <div className="bookingFlow__entryTitle">Escolha os procedimentos</div>
                         <div className="bookingFlow__cardSub">Selecione um ou mais procedimentos para o seu atendimento.</div>
                         {!canPickProcedure ? (
@@ -1119,7 +1126,7 @@ export default function BookingFlow() {
                                 <div className="bookingFlow__lockText">Selecione a unidade no topo para continuar.</div>
                             </div>
                         ) : null}
-                        <HoverScrollPicker ariaLabel="Lista de procedimentos" className="bookingFlow__picker--bleed">
+                        <HoverScrollPicker ariaLabel="Lista de procedimentos" className="bookingFlow__picker--bleed bookingFlow__picker--rail">
                             <div className="bookingFlow__procedureBadgeGrid">
                                 {services.map((s) => {
                                     const active = selectedServices.some((item) => item.id === s.id);
@@ -1172,7 +1179,7 @@ export default function BookingFlow() {
                         </HoverScrollPicker>
                     </div>
 
-                    <div className={`card bookingFlow__cardFull bookingFlow__cardDateTime ${canPick ? "" : "bookingFlow__card--locked"}`.trim()} style={{ padding: 16 }}>
+                    <div className={`card bookingFlow__cardFull bookingFlow__cardDateTime ${canPick ? "" : "bookingFlow__card--locked"}`.trim()} style={{ padding: 14 }}>
                         <div className="bookingFlow__cardHeader">
                             <div>
                                 <div className="bookingFlow__entryTitle">Data e horário</div>
@@ -1192,7 +1199,7 @@ export default function BookingFlow() {
                         {!canPick ? (
                             <div className="bookingFlow__lockOverlay" aria-hidden="true">
                                 <div className="bookingFlow__lockText">
-                                    {!unitSlug ? "Selecione a unidade no topo para ver horários." : "Escolha ao menos um procedimento para liberar a agenda."}
+                                    Selecione a unidade no topo para ver horários.
                                 </div>
                             </div>
                         ) : null}
@@ -1217,6 +1224,7 @@ export default function BookingFlow() {
                                                         data-active={active ? "true" : "false"}
                                                         data-unavailable={unavailable ? "true" : "false"}
                                                         onClick={() => {
+                                                            ensureDefaultSelections();
                                                             setDateTouched(true);
                                                             if (active) {
                                                                 setDateKey(null);
@@ -1332,7 +1340,7 @@ export default function BookingFlow() {
                                             })}
                                         </div>
                                     ) : (
-                                        <div className="small">Escolha um procedimento para filtrar horários ou selecione uma data.</div>
+                                        <div className="small">Selecione uma data para ver os horários disponíveis.</div>
                                     )}
                                 </div>
                             </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1123,9 +1123,9 @@ button:focus-visible {
 }
 
 .bookingFlow__cardSub {
-  margin-top: 6px;
+  margin-top: 4px;
   font-size: 12px;
-  line-height: 1.45;
+  line-height: 1.35;
   color: #5f5f5f;
   opacity: 1;
 }
@@ -1404,7 +1404,7 @@ button:focus-visible {
 .bookingFlow__doctorBadgeGrid {
   display: flex;
   flex-wrap: nowrap;
-  gap: 12px;
+  gap: 8px;
   align-items: flex-start;
   width: max-content;
   min-width: 100%;
@@ -1421,7 +1421,7 @@ button:focus-visible {
   left: 14px;
   right: 14px;
   top: 100%;
-  height: 10px;
+  height: 8px;
 }
 
 .bookingFlow__doctorBadge {
@@ -1490,6 +1490,10 @@ button:focus-visible {
   letter-spacing: -0.05em;
   color: #fff;
   text-align: center;
+}
+
+.bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap {
+  padding-top: 6px;
 }
 
 .bookingFlow__doctorTooltip {
@@ -1573,7 +1577,7 @@ button:focus-visible {
   appearance: none;
   display: grid;
   justify-items: center;
-  gap: 6px;
+  gap: 5px;
   width: 104px;
   min-width: 104px;
   flex: 0 0 auto;
@@ -1646,14 +1650,14 @@ button:focus-visible {
 .bookingFlow__procedureBadgeLabel {
   font-size: 12px;
   font-weight: 900;
-  line-height: 1.15;
+  line-height: 1.1;
   text-align: center;
   text-wrap: balance;
 }
 
 .bookingFlow__procedureBadgeSub {
   font-size: 11px;
-  line-height: 1.25;
+  line-height: 1.18;
   color: var(--muted);
   text-align: center;
   text-wrap: balance;
@@ -1793,7 +1797,7 @@ button:focus-visible {
 
 .bookingFlow__picker {
   position: relative;
-  margin-top: 10px;
+  margin-top: 6px;
   overflow: visible;
   border-radius: 18px;
   width: 100%;
@@ -1804,25 +1808,46 @@ button:focus-visible {
   margin-right: -16px;
 }
 
+.bookingFlow__picker--rail::before,
+.bookingFlow__picker--rail::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 76px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.bookingFlow__picker--rail::before {
+  left: 0;
+  background: linear-gradient(90deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
+}
+
+.bookingFlow__picker--rail::after {
+  right: 0;
+  background: linear-gradient(270deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
+}
+
 .bookingFlow__picker .bookingFlow__scrollWindow {
   margin-top: 0;
-  padding-left: 72px;
-  padding-right: 72px;
-  padding-top: 10px;
-  padding-bottom: 18px;
-  scroll-padding-left: 72px;
-  scroll-padding-right: 72px;
+  padding-left: 78px;
+  padding-right: 78px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  scroll-padding-left: 78px;
+  scroll-padding-right: 78px;
 }
 
 .bookingFlow__scrollWindow--doctor {
-  padding-top: 52px !important;
+  padding-top: 8px !important;
 }
 
 .bookingFlow__hoverZone {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 2;
+  top: 8px;
+  height: 82px;
+  z-index: 3;
   width: 72px;
   border: 0;
   padding: 0;
@@ -1847,13 +1872,11 @@ button:focus-visible {
 .bookingFlow__hoverZone--left {
   left: 0;
   justify-content: flex-start;
-  background: linear-gradient(90deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
 }
 
 .bookingFlow__hoverZone--right {
   right: 0;
   justify-content: flex-end;
-  background: linear-gradient(270deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
 }
 
 .bookingFlow__scrollArrow {
@@ -1900,7 +1923,7 @@ button:focus-visible {
 }
 
 .bookingFlow__scrollWindow {
-  margin-top: 10px;
+  margin-top: 0;
   width: 100%;
   display: flex;
   gap: 10px;
@@ -1925,6 +1948,10 @@ button:focus-visible {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
   gap: 6px;
+}
+
+.bookingFlow__cardDateTime .bookingFlow__cardHeader {
+  align-items: flex-start;
 }
 
 .bookingFlow__timeBtnText {


### PR DESCRIPTION
## Summary

This update aligns the doctor and procedure rails so both components share the same visual rhythm, edge treatment, and interaction model, while also reducing unnecessary vertical space in the cards.

Both rails now use the same masked edge treatment on the left and right, their arrows are vertically centered on the badge row, badge spacing is tighter, and the card padding and copy spacing were compressed to reduce overall height without crowding the layout. The doctor rail was also nudged upward so its badges sit on the same visual line as the procedure badges.

The scheduling flow was relaxed so date and time can be used without manually choosing a doctor or procedure first. When the user interacts directly with the calendar or slot grid, the flow now auto-selects Sem Preferência and Outro in the background, preserving a valid booking state without forcing a manual step earlier in the flow.

## Validation

- npm run build
- npm run typecheck
- local Playwright visual check on /agendamento with unidade selecionada
- local DOM verification that direct calendar interaction activates Sem Preferência and Outro
