### PR TITLE
Fix booking tooltips and rail fade

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -1136,8 +1136,9 @@ export default function BookingFlow() {
                                             type="button"
                                             role="listitem"
                                             disabled={!canPickProcedure}
-                                            className="bookingFlow__procedureBadge"
+                                            className={`bookingFlow__procedureBadge${s.subtitle ? " bookingFlow__tooltipTrigger bookingFlow__procedureBadge--hasTooltip" : ""}`}
                                             data-active={active ? "true" : "false"}
+                                            data-tooltip={s.subtitle ?? undefined}
                                             onClick={() => toggleProcedure(s)}
                                         >
                                             <span className="bookingFlow__procedureBadgeAvatar">
@@ -1156,7 +1157,6 @@ export default function BookingFlow() {
                                                 )}
                                             </span>
                                             <span className="bookingFlow__procedureBadgeLabel">{s.name}</span>
-                                            {s.subtitle ? <span className="bookingFlow__procedureBadgeSub">{s.subtitle}</span> : null}
                                         </button>
                                     );
                                 })}
@@ -1165,16 +1165,16 @@ export default function BookingFlow() {
                                     type="button"
                                     role="listitem"
                                     disabled={!canPickProcedure}
-                                    className="bookingFlow__procedureBadge"
+                                    className="bookingFlow__procedureBadge bookingFlow__tooltipTrigger bookingFlow__procedureBadge--hasTooltip"
                                     data-active={selectedServices.some((item) => item.id === OTHER_SERVICE.id) ? "true" : "false"}
-                                            onClick={() => toggleProcedure(OTHER_SERVICE)}
-                                        >
-                                            <span className="bookingFlow__procedureBadgeAvatar bookingFlow__procedureBadgeAvatar--all">
-                                                <span className="bookingFlow__procedureBadgeFallback bookingFlow__procedureBadgeFallback--all">Outro</span>
-                                            </span>
-                                            <span className="bookingFlow__procedureBadgeLabel">Outro</span>
-                                            <span className="bookingFlow__procedureBadgeSub">Outro procedimento ou combinação</span>
-                                        </button>
+                                    data-tooltip="Outro procedimento ou combinação"
+                                    onClick={() => toggleProcedure(OTHER_SERVICE)}
+                                >
+                                    <span className="bookingFlow__procedureBadgeAvatar bookingFlow__procedureBadgeAvatar--all">
+                                        <span className="bookingFlow__procedureBadgeFallback bookingFlow__procedureBadgeFallback--all">Outro</span>
+                                    </span>
+                                    <span className="bookingFlow__procedureBadgeLabel">Outro</span>
+                                </button>
                             </div>
                         </HoverScrollPicker>
                     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1507,26 +1507,20 @@ button:focus-visible {
 .bookingFlow__doctorTooltip {
   position: absolute;
   left: 50%;
-  bottom: calc(100% + 8px);
+  bottom: calc(100% + 6px);
   top: auto;
-  transform: translateX(-50%) translateY(4px);
+  transform: translateX(-50%);
+  display: none;
   width: max-content;
-  min-width: 0;
-  max-width: 0;
-  padding: 0;
+  min-width: 132px;
+  max-width: 210px;
+  padding: 8px 10px;
   border-radius: 12px;
   background: rgba(17, 17, 17, 0.96);
   color: #fff;
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
-  overflow: hidden;
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    opacity 180ms ease 180ms,
-    transform 180ms ease 180ms,
-    min-width 0s linear 180ms,
-    max-width 0s linear 180ms,
-    padding 0s linear 180ms;
+  white-space: normal;
+  pointer-events: auto;
   z-index: 4;
 }
 
@@ -1539,13 +1533,7 @@ button:focus-visible {
 
 .bookingFlow__doctorBadgeWrap:hover .bookingFlow__doctorTooltip,
 .bookingFlow__doctorBadgeWrap:focus-within .bookingFlow__doctorTooltip {
-  min-width: 132px;
-  max-width: 210px;
-  padding: 8px 10px;
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateX(-50%) translateY(0);
-  transition-delay: 0s, 0s, 0s, 0s, 0s;
+  display: block;
 }
 
 .bookingFlow__doctorTooltipName {
@@ -1680,16 +1668,15 @@ button:focus-visible {
   text-wrap: balance;
 }
 
-.bookingFlow__procedureBadgeSub {
-  font-size: 11px;
-  line-height: 1.18;
-  color: var(--muted);
-  text-align: center;
-  text-wrap: balance;
-}
-
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeLabel {
   color: #111;
+}
+
+.bookingFlow__procedureBadge--hasTooltip::after {
+  max-width: 188px;
+  text-align: center;
+  white-space: normal;
+  text-wrap: balance;
 }
 
 .bookingFlow__dateBtn {
@@ -1846,12 +1833,12 @@ button:focus-visible {
 
 .bookingFlow__picker--rail::before {
   left: 0;
-  background: linear-gradient(90deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
+  background: linear-gradient(90deg, rgba(246, 246, 246, 0.72) 0%, rgba(246, 246, 246, 0) 100%);
 }
 
 .bookingFlow__picker--rail::after {
   right: 0;
-  background: linear-gradient(270deg, rgba(246, 246, 246, 0.98) 0%, rgba(246, 246, 246, 0) 100%);
+  background: linear-gradient(270deg, rgba(246, 246, 246, 0.72) 0%, rgba(246, 246, 246, 0) 100%);
 }
 
 .bookingFlow__picker .bookingFlow__scrollWindow {


### PR DESCRIPTION
## Summary
- restore doctor tooltips while keeping them out of the rail scroll width
- move procedure subtitles into hover tooltips and keep only the main label visible under each badge
- soften the rail fade overlays so the badge area blends into the card background

## Testing
- npm run build
- npm run typecheck
- local Playwright validation for doctor tooltip visibility, procedure tooltip hover, and doctor rail edge alignment