### PR TITLE
Stabilize booking team directory loading

### DIFF
--- a/src/hooks/useTeamDirectory.ts
+++ b/src/hooks/useTeamDirectory.ts
@@ -25,6 +25,7 @@ type TeamDirectoryState = {
 let cachedMembers: TeamDirectoryMember[] | null = null;
 let cachedError: string | null = null;
 let inflightLoad: Promise<void> | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
 const listeners = new Set<() => void>();
 
@@ -42,19 +43,40 @@ function notifyListeners() {
 }
 
 async function loadTeamDirectory() {
-    if (cachedMembers !== null || cachedError !== null) return;
+    if (cachedMembers !== null) return;
     if (inflightLoad) return inflightLoad;
+
+    if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+    }
 
     inflightLoad = (async () => {
         try {
             const res = await fetch("/api/equipe", { cache: "no-store" });
             const json = (await res.json().catch(() => null)) as TeamDirectoryResponse | null;
 
-            cachedMembers = Array.isArray(json?.members) ? json.members : [];
-            cachedError = json && json.ok === false ? json.error?.code ?? "unknown" : null;
+            const nextMembers = Array.isArray(json?.members) ? json.members : [];
+            const nextError = json && json.ok === false ? json.error?.code ?? "unknown" : null;
+
+            if (nextError) {
+                cachedMembers = null;
+                cachedError = nextError;
+                retryTimer = setTimeout(() => {
+                    retryTimer = null;
+                    void loadTeamDirectory();
+                }, 4000);
+            } else {
+                cachedMembers = nextMembers;
+                cachedError = null;
+            }
         } catch {
-            cachedMembers = [];
+            cachedMembers = null;
             cachedError = "exception";
+            retryTimer = setTimeout(() => {
+                retryTimer = null;
+                void loadTeamDirectory();
+            }, 4000);
         } finally {
             inflightLoad = null;
             notifyListeners();

--- a/src/lib/injectorsDirectory.ts
+++ b/src/lib/injectorsDirectory.ts
@@ -36,6 +36,17 @@ type CloudflareEnv = {
     GOOGLE_SERVICE_ACCOUNT_JSON?: string;
 };
 
+type InjectorsResult = { ok: true; members: TeamMember[] } | { ok: false; members: TeamMember[]; error: InjectorsDirectoryError };
+type InjectorsCacheEntry = {
+    expiresAtMs: number;
+    result: InjectorsResult;
+};
+
+const INJECTORS_CACHE_TTL_MS = 5 * 60_000;
+const INJECTORS_ERROR_CACHE_TTL_MS = 10_000;
+let injectorsCache: InjectorsCacheEntry | null = null;
+let inflightInjectorsLoad: Promise<InjectorsResult> | null = null;
+
 type GoogleServiceAccount = {
     client_email?: string;
     private_key?: string;
@@ -312,7 +323,12 @@ export function unitLabelFromBookingUnitSlug(unitSlug: string): string | null {
     return null;
 }
 
-export async function fetchActiveInjectorsResult(): Promise<{ ok: true; members: TeamMember[] } | { ok: false; members: TeamMember[]; error: InjectorsDirectoryError }> {
+export async function fetchActiveInjectorsResult(): Promise<InjectorsResult> {
+    const now = Date.now();
+    if (injectorsCache && injectorsCache.expiresAtMs > now) return injectorsCache.result;
+    if (inflightInjectorsLoad) return inflightInjectorsLoad;
+
+    inflightInjectorsLoad = (async () => {
     try {
         const env = getEnv();
         const serviceAccountJson = (env.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON ?? env.GOOGLE_SERVICE_ACCOUNT_JSON ?? "").trim();
@@ -398,6 +414,18 @@ export async function fetchActiveInjectorsResult(): Promise<{ ok: true; members:
         return { ok: true, members };
     } catch {
         return { ok: false, members: [], error: { code: "exception" } };
+    }
+    })();
+
+    try {
+        const result = await inflightInjectorsLoad;
+        injectorsCache = {
+            expiresAtMs: Date.now() + (result.ok ? INJECTORS_CACHE_TTL_MS : INJECTORS_ERROR_CACHE_TTL_MS),
+            result,
+        };
+        return result;
+    } finally {
+        inflightInjectorsLoad = null;
     }
 }
 


### PR DESCRIPTION
## Summary
- add retry behavior to the client-side team directory hook so transient failures do not stay stuck in the session
- add server-side caching and inflight deduplication for the injectors directory to avoid repeated Sheets reads across booking slots requests
- cache failures only briefly so the booking flow can recover automatically

## Testing
- npm run build
- npm run typecheck
- curl https://espacofacial.com/api/equipe
- curl https://espacofacial.com/api/booking/slots?... after deploy